### PR TITLE
Add showReference flag to config.yaml

### DIFF
--- a/changelog.yaml
+++ b/changelog.yaml
@@ -1,2 +1,3 @@
 sct:
   name: gitchanges
+  showReference: false


### PR DESCRIPTION
To allow references to be displayed or hidden in the template.

version: 0.1.0
tag: Added